### PR TITLE
Fix spinner bug

### DIFF
--- a/src/components/spinner.js
+++ b/src/components/spinner.js
@@ -42,8 +42,8 @@ export default function Spinner ({
               cx: 50,
               cy: 50,
               r: 48,
-              strokeWidth: 4,
-              strokeMiterlimit: 10
+              'stroke-width': 4,
+              'stroke-miterlimit': 10
             },
             style: {
               strokeDasharray: '1,400',


### PR DESCRIPTION
Fixes #17 . The problem is that with SVG, attributes are case insensitive. Something similar like [here](http://stackoverflow.com/questions/26457455/setting-attribute-value-of-an-element-in-camelcase-using-a-directive).
